### PR TITLE
Allocate and release unique IDs based on build directory

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -49,6 +49,8 @@ test =
 junit_suite_name = colcon-ros-domain-id-coordinator
 
 [options.entry_points]
+colcon_core.event_handler =
+    ros_domain_id = colcon_ros_domain_id_coordinator.shell.ros_domain_id:ROSDomainIDShell
 colcon_core.shell =
     ros_domain_id = colcon_ros_domain_id_coordinator.shell.ros_domain_id:ROSDomainIDShell
 

--- a/test/spell_check.words
+++ b/test/spell_check.words
@@ -9,6 +9,7 @@ pathlib
 plugin
 prepend
 pytest
+qsize
 scspell
 setuptools
 thomas


### PR DESCRIPTION
With this change, we should have confidence that the allocated IDs are unique given that there are sufficient IDs available to fan out to the requested number of execution slots.

If we run out, a warning will be printed and the job will have no ROS_DOMAIN_ID value set.

Full CI, since paths are involved:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=19540)](http://ci.ros2.org/job/ci_linux/19540/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=14056)](http://ci.ros2.org/job/ci_linux-aarch64/14056/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=20258)](http://ci.ros2.org/job/ci_windows/20258/)