### PR TITLE
Disable downstream isolation mechanisms

### DIFF
--- a/colcon_ros_domain_id_coordinator/shell/ros_domain_id.py
+++ b/colcon_ros_domain_id_coordinator/shell/ros_domain_id.py
@@ -105,8 +105,11 @@ class ROSDomainIDShell(EventHandlerExtensionPoint, ShellExtensionPoint):
             else:
                 os.environ['ROS_DOMAIN_ID'] = self._default_id
         else:
+            # Used for the domain_coordinator by ament_cmake_ros
             os.environ['DISABLE_ROS_ISOLATION'] = '1'
+            # Used by rmw_test_fixture_implementation
             os.environ['RMW_TEST_FIXTURE_DISABLE_ISOLATION'] = '1'
+            # Attempt to keep tests off the host's network
             os.environ['ROS_AUTOMATIC_DISCOVERY_RANGE'] = 'LOCALHOST'
             os.environ['ROS_DOMAIN_ID'] = domain_id
             logger.debug(

--- a/colcon_ros_domain_id_coordinator/shell/ros_domain_id.py
+++ b/colcon_ros_domain_id_coordinator/shell/ros_domain_id.py
@@ -105,6 +105,9 @@ class ROSDomainIDShell(EventHandlerExtensionPoint, ShellExtensionPoint):
             else:
                 os.environ['ROS_DOMAIN_ID'] = self._default_id
         else:
+            os.environ['DISABLE_ROS_ISOLATION'] = '1'
+            os.environ['RMW_TEST_FIXTURE_DISABLE_ISOLATION'] = '1'
+            os.environ['ROS_AUTOMATIC_DISCOVERY_RANGE'] = 'LOCALHOST'
             os.environ['ROS_DOMAIN_ID'] = domain_id
             logger.debug(
                 f"Allocated ROS_DOMAIN_ID={domain_id} for '{build_base}'")

--- a/test/spell_check.words
+++ b/test/spell_check.words
@@ -1,5 +1,7 @@
+ament
 apache
 asyncio
+cmake
 colcon
 cottsay
 darwin

--- a/test/spell_check.words
+++ b/test/spell_check.words
@@ -5,6 +5,7 @@ cottsay
 darwin
 iterdir
 linter
+localhost
 noqa
 pathlib
 plugin


### PR DESCRIPTION
If downstream isolation mechanisms set ROS_DOMAIN_ID as well, there's a chance that we could collide. Better to choose only a single mechanism and stick with that.