### PR TITLE
Revert ROS_AUTOMATIC_DISCOVERY_RANGE change

### DIFF
--- a/colcon_ros_domain_id_coordinator/shell/ros_domain_id.py
+++ b/colcon_ros_domain_id_coordinator/shell/ros_domain_id.py
@@ -109,8 +109,6 @@ class ROSDomainIDShell(EventHandlerExtensionPoint, ShellExtensionPoint):
             os.environ['DISABLE_ROS_ISOLATION'] = '1'
             # Used by rmw_test_fixture_implementation
             os.environ['RMW_TEST_FIXTURE_DISABLE_ISOLATION'] = '1'
-            # Attempt to keep tests off the host's network
-            os.environ['ROS_AUTOMATIC_DISCOVERY_RANGE'] = 'LOCALHOST'
             os.environ['ROS_DOMAIN_ID'] = domain_id
             logger.debug(
                 f"Allocated ROS_DOMAIN_ID={domain_id} for '{build_base}'")

--- a/test/spell_check.words
+++ b/test/spell_check.words
@@ -7,7 +7,6 @@ cottsay
 darwin
 iterdir
 linter
-localhost
 noqa
 pathlib
 plugin


### PR DESCRIPTION
I belive this is causing flakiness on Windows builds. Until we can investigate, let's drop this change.