### PR TITLE
Coordinate with downstream isolation rather than disable it

### DIFF
--- a/test/spell_check.words
+++ b/test/spell_check.words
@@ -1,13 +1,11 @@
-ament
 apache
 asyncio
-cmake
 colcon
 cottsay
 darwin
+inet
 iterdir
 linter
-localhost
 noqa
 pathlib
 plugin


### PR DESCRIPTION
Instead of disabling downstream isolation, use the same port locking strategy used there to ensure that we don't allocate the same port to multiple tests.

This will cause some unnecessary allocation where both mechanisms lock a port for the same package, but we have lots of available ports and far fewer packages to build simultaneously.

Reverts 6caa8f04cd09135c10eea86819bdbaa913cf95d6